### PR TITLE
fix: write logs in cwd directory before config resolve finished

### DIFF
--- a/src/lib/config/commanderArgv.ts
+++ b/src/lib/config/commanderArgv.ts
@@ -85,7 +85,7 @@ export async function resolveConfig(commanderArgv: Command): Promise<IConfig> {
     initBrowserProfile(config);
 
     if (!isInteractive()) {
-        config.silent = true;
+        config.withoutUi = true;
     }
 
     normalizeMetrics(config);

--- a/src/lib/config/default.ts
+++ b/src/lib/config/default.ts
@@ -7,7 +7,7 @@ export default (): IConfig => ({
     iterations: 70,
     workers: 1,
     pageTimeout: 20, // in seconds
-    silent: false,
+    withoutUi: false,
     puppeteerOptions: {
         headless: true,
         ignoreHTTPSErrors: false,

--- a/src/lib/config/schema.ts
+++ b/src/lib/config/schema.ts
@@ -28,7 +28,7 @@ const schema = joi.object().required().keys({
     iterations: joi.number().integer().min(1), // --------- how many iterations on compare
     workers: joi.number().integer().min(1),
     pageTimeout: joi.number().integer().min(0),
-    silent: joi.boolean().default(false),
+    withoutUi: joi.boolean().default(false),
     puppeteerOptions: joi.object().required().keys({ // ----------------------------
         headless: joi.boolean().default(true), // ------------------------- start headless chromium
         ignoreHTTPSErrors: joi.boolean().default(false),

--- a/src/lib/config/types.ts
+++ b/src/lib/config/types.ts
@@ -102,7 +102,7 @@ export interface IConfig {
   iterations: number;
   workers: number;
   pageTimeout: number;
-  silent: boolean;
+  withoutUi: boolean;
   puppeteerOptions: IPuppeteerOptions;
   webdriverOptions: IWebdriverOptions;
   browserProfile: IBrowserProfile;

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 
-import {isInteractive} from '@/lib/helpers';
+import {isInteractive as getIsInteractive} from '@/lib/helpers';
 import * as fs from 'fs';
 import * as tracer from 'tracer';
 
@@ -28,7 +28,8 @@ process.on('beforeExit', function handleBeforeExit() {
 });
 
 export const createLogger = (level: string = 'trace') => {
-    const loggerCreator = isInteractive() ? tracer.colorConsole : tracer.console;
+    const isInteractive = getIsInteractive();
+    const loggerCreator = isInteractive ? tracer.colorConsole : tracer.console;
 
     return loggerCreator({
         level,
@@ -40,10 +41,13 @@ export const createLogger = (level: string = 'trace') => {
         ],
         dateformat: 'HH:MM:ss.L',
         transport(data) {
+            if (!isInteractive) {
+                process.stderr.write(data.rawoutput + '\n');
+            }
+
             viewConsole.info(data.output);
 
             if (logfilePath) {
-
                 if (!logfileDescriptor) {
                     logfileDescriptor = fs.openSync(logfilePath, 'a');
                 }
@@ -52,7 +56,6 @@ export const createLogger = (level: string = 'trace') => {
                     if (err) { throw err; }
                 });
             }
-
         },
     });
 };

--- a/src/lib/puppeteer/runCheck.ts
+++ b/src/lib/puppeteer/runCheck.ts
@@ -75,7 +75,7 @@ export async function runPuppeteerCheck(
         let customMetrics = {};
 
         if (config.hooks && config.hooks.onCollectMetrics) {
-            logger.info(`[onCollectMetrics hook] collect custom metrics for site ${site.name} (${site.url})`);
+            logger.trace(`[onCollectMetrics hook] collect custom metrics for site ${site.name} (${site.url})`);
             customMetrics = await config.hooks.onCollectMetrics({logger, page, comparison, site});
         }
 

--- a/src/lib/view.ts
+++ b/src/lib/view.ts
@@ -99,7 +99,7 @@ class TableView {
     }
 
     public init = () => {
-        if (this.config.silent) {
+        if (this.config.withoutUi) {
             return;
         }
 
@@ -127,7 +127,7 @@ class TableView {
         iterations: number[],
         activeTests: number[],
     }) => {
-        if (this.config.silent) {
+        if (this.config.withoutUi) {
             return;
         }
 
@@ -198,7 +198,7 @@ class TableView {
     }
 
     public shutdown = (errorHappened: boolean) => {
-        if (!this.config.silent) {
+        if (!this.config.withoutUi) {
             this.screen.destroy();
 
             if (this.tableText) {

--- a/src/lib/workerFarm.ts
+++ b/src/lib/workerFarm.ts
@@ -98,7 +98,7 @@ export default async function startWorking(
     function registerMetrics([originalMetrics, siteIndex]: [IOriginalMetrics, number]): void {
         const transformedMetrics: number[] = [];
 
-        logger.trace(`workerFarm registerMetrics: ${originalMetrics}`);
+        logger.trace('workerFarm registerMetrics:', siteIndex, originalMetrics);
 
         for (let metricIndex = 0; metricIndex < config.metrics.length; metricIndex++) {
             const metricName = config.metrics[metricIndex].name;

--- a/src/lib/wpr/index.ts
+++ b/src/lib/wpr/index.ts
@@ -69,7 +69,7 @@ const openPageWithRetries = async (
             await page.goto(site.url, {waitUntil: 'networkidle0'});
 
             if (onVerifyWprHook) {
-                logger.info(`[recordWprArchives] verify page ${site.name} (${site.url}) with onVerifyWpr hook`);
+                logger.trace(`[recordWprArchives] verify page ${site.name} (${site.url}) with onVerifyWpr hook`);
                 await onVerifyWprHook();
             }
 
@@ -173,7 +173,7 @@ export const recordWprArchives = async (comparison: IComparison, config: IConfig
             const site = sites[siteIndex];
             const browser = browsers[siteIndex];
 
-            logger.info(`[recordWprArchives] record wpr archive for ${site.name}`);
+            logger.trace(`[recordWprArchives] record wpr archive for ${site.name}`);
 
             const pageProfile = preparePageProfile(config);
 
@@ -218,7 +218,7 @@ export const recordWprArchives = async (comparison: IComparison, config: IConfig
             const site = sites[siteIndex];
             const browser = browsers[siteIndex];
 
-            logger.info(`[recordWprArchives] get page structure sizes for ${site.name}`);
+            logger.trace(`[recordWprArchives] get page structure sizes for ${site.name}`);
 
             const pageProfile: IPageProfile = {
                 ...preparePageProfile(config),


### PR DESCRIPTION
до того как мы прочитали конфиг, логи пишутся только в screen
на этапе когда мы только резолвим конфиг, может возникнуть ошибка и ее не будет нигде видно

видео: https://yadi.sk/i/XVUscPwiV_vggQ

по умолчанию пишем логи в `${process.cwd}/porchmark.log`, а после того как конфиг прочитан и есть config.workDir закрываем логфайл и начинаем писать в новый