### PR TITLE
Feature: improved report json format

### DIFF
--- a/src/bin/porchmark-compare.ts
+++ b/src/bin/porchmark-compare.ts
@@ -12,7 +12,7 @@ const logger = createLogger();
 setLogger(logger);
 
 import {startComparison} from '@/lib/comparison';
-import {resolveConfig} from '@/lib/config';
+import {resolveConfig, saveConfig} from '@/lib/config';
 import {getView} from '@/lib/view';
 
 const view = getView();
@@ -50,6 +50,8 @@ program
         const logfilePath = path.resolve(config.workDir, 'porchmark.log');
 
         setLogfilePath(logfilePath);
+
+        await saveConfig(logger, config);
 
         logger.info('config', config);
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,6 @@
+// tslint:disable-next-line no-var-requires
+const pkg = require('@/../package.json');
+
+export const PORCHMARK_VERSION = pkg.version;
+
+export const PORCHMARK_REPORT_VERSION = 1.0;

--- a/src/lib/comparison.ts
+++ b/src/lib/comparison.ts
@@ -1,5 +1,5 @@
 import fs from 'fs-extra';
-import {ChartReport} from 'porchmark-pretty-reporter';
+// import {ChartReport} from 'porchmark-pretty-reporter';
 
 import {IComparison, IConfig} from '@/lib/config';
 import {DataProcessor} from '@/lib/dataProcessor';
@@ -7,6 +7,7 @@ import {getLogger} from '@/lib/logger';
 import {HumanReport, JsonReport, saveReports} from '@/lib/report';
 
 import {getComparisonDir} from '@/lib/fs';
+import {isoDate} from '@/lib/helpers';
 import {getView} from '@/lib/view';
 import startWorking from '@/lib/workerFarm';
 import {recordWprArchives} from '@/lib/wpr';
@@ -17,6 +18,8 @@ const logger = getLogger();
 const view = getView();
 
 export async function startComparison(config: IConfig, comparison: IComparison) {
+    const startedAt = isoDate();
+
     logger.info(`pid=${process.pid}`);
 
     const dataProcessor = new DataProcessor(config, comparison);
@@ -76,7 +79,11 @@ export async function startComparison(config: IConfig, comparison: IComparison) 
 
         const jsonRawReport = await dataProcessor.calcReport(comparison.sites);
 
+        const completedAt = isoDate();
+
         await saveReports({
+            startedAt,
+            completedAt,
             jsonRawReport,
             config,
             id: 'total',
@@ -84,7 +91,8 @@ export async function startComparison(config: IConfig, comparison: IComparison) 
             reporters: [
                 HumanReport,
                 JsonReport,
-                ChartReport,
+                // TODO fix types in https://github.com/re-gor/porchmark-pretty-reporter
+                // ChartReport,
             ],
         });
 

--- a/src/lib/comparison.ts
+++ b/src/lib/comparison.ts
@@ -81,9 +81,15 @@ export async function startComparison(config: IConfig, comparison: IComparison) 
 
         const completedAt = isoDate();
 
+        // TODO process status and status message
+        const status = 'not_implemented';
+        const statusMessage = 'not implemented yet';
+
         await saveReports({
             startedAt,
             completedAt,
+            status,
+            statusMessage,
             jsonRawReport,
             config,
             id: 'total',

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -2,9 +2,11 @@ export * from './types';
 export * from './commanderArgv';
 
 import joi from '@hapi/joi';
+import fs from 'fs-extra';
 import {defaultsDeep} from 'lodash';
 
 import {IConfig} from '@/lib/config/types';
+import {Logger} from '@/lib/logger';
 
 import getDefaultConfig from './default';
 import schema from './schema';
@@ -32,9 +34,29 @@ const validateConfig = (rawConfig: any): Promise<IConfig> => {
     return schema.validateAsync(rawConfig, options);
 };
 
+const getConfigFilepath = (workdir: string): string => `${workdir}/porchmark.config.json`;
+
+const saveConfig = async (logger: Logger, config: IConfig): Promise<void> => {
+    const data = JSON.stringify(config, undefined, 2);
+
+    let configFilepath = getConfigFilepath(config.workDir);
+
+    const configExists = await fs.pathExists(configFilepath);
+
+    if (configExists) {
+        const newConfigFilepath = `${configFilepath}-${Date.now()}`;
+        logger.warn(`config ${configFilepath} already exists, save config to ${newConfigFilepath}`);
+        configFilepath = newConfigFilepath;
+    }
+
+    await fs.writeFile(configFilepath, data);
+};
+
 export {
     getDefaultConfig,
     schema,
     mergeWithDefaults,
     validateConfig,
+    getConfigFilepath,
+    saveConfig,
 };

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -52,3 +52,5 @@ export function isInteractive(): boolean {
 export function assertNonNull<T>(obj: T): asserts obj is NonNullable<T> {
     assert.notEqual(obj, null);
 }
+
+export const isoDate = () => (new Date()).toISOString();

--- a/src/lib/report/__spec__/mock.ts
+++ b/src/lib/report/__spec__/mock.ts
@@ -621,6 +621,8 @@ export const jsonReportResult = {
     reportVersion: PORCHMARK_REPORT_VERSION,
     startedAt: isoDate,
     completedAt: isoDate,
+    status: 'success',
+    statusMessage: 'okay',
     ...jsonRawReportResult,
     data: {
         ...jsonRawReportResult.data,

--- a/src/lib/report/__spec__/mock.ts
+++ b/src/lib/report/__spec__/mock.ts
@@ -6,6 +6,8 @@ import { sites, jsonReportResult as jsonRawReportResult} from '@/lib/dataProcess
 
 export {sites, jsonRawReportResult};
 
+export const isoDate = '2021-05-04T11:58:48.552Z';
+
 export const humanReportResult = {
     "headers": [
       "metric",
@@ -617,6 +619,8 @@ export const humanReportResult = {
 export const jsonReportResult = {
     version: PORCHMARK_VERSION,
     reportVersion: PORCHMARK_REPORT_VERSION,
+    startedAt: isoDate,
+    completedAt: isoDate,
     ...jsonRawReportResult,
     data: {
         ...jsonRawReportResult.data,

--- a/src/lib/report/__spec__/mock.ts
+++ b/src/lib/report/__spec__/mock.ts
@@ -1,5 +1,6 @@
-
 /* tslint:disable */
+
+import {PORCHMARK_REPORT_VERSION, PORCHMARK_VERSION} from '@/constants';
 
 import { sites, jsonReportResult as jsonRawReportResult} from '@/lib/dataProcessor/__spec__/mock';
 
@@ -611,9 +612,11 @@ export const humanReportResult = {
         ]
       ]
   }
-  
+
 
 export const jsonReportResult = {
+    version: PORCHMARK_VERSION,
+    reportVersion: PORCHMARK_REPORT_VERSION,
     ...jsonRawReportResult,
     data: {
         ...jsonRawReportResult.data,

--- a/src/lib/report/__spec__/report.spec.ts
+++ b/src/lib/report/__spec__/report.spec.ts
@@ -16,6 +16,8 @@ describe('Reports:', () => {
             reporter.prepareData({
                 startedAt: isoDate(),
                 completedAt: isoDate(),
+                status: 'success',
+                statusMessage: 'okay',
                 config: getDefaultConfig(),
                 report: jsonRawReportResult,
             });
@@ -30,6 +32,8 @@ describe('Reports:', () => {
             reporter.prepareData({
                 startedAt: isoDate(),
                 completedAt: isoDate(),
+                status: 'success',
+                statusMessage: 'okay',
                 config: getDefaultConfig(),
                 report: jsonRawReportResult,
             });

--- a/src/lib/report/__spec__/report.spec.ts
+++ b/src/lib/report/__spec__/report.spec.ts
@@ -1,14 +1,24 @@
 import getDefaultConfig from '@/lib/config/default';
+import {isoDate} from '@/lib/helpers';
 import { HumanReport } from '../humanReport';
 import { JsonReport } from '../jsonReport';
-import { humanReportResult, jsonRawReportResult, jsonReportResult} from './mock';
+import { humanReportResult, isoDate as isoDateMock, jsonRawReportResult, jsonReportResult} from './mock';
+
+jest.mock('@/lib/helpers', () => ({
+    isoDate: jest.fn(() => isoDateMock),
+}));
 
 describe('Reports:', () => {
 
     describe('humanReport', () => {
         it('provides table-view of raw json report', () => {
             const reporter = new HumanReport();
-            reporter.prepareData(getDefaultConfig(), jsonRawReportResult);
+            reporter.prepareData({
+                startedAt: isoDate(),
+                completedAt: isoDate(),
+                config: getDefaultConfig(),
+                report: jsonRawReportResult,
+            });
 
             expect(reporter.exposeInternalView()).toEqual(humanReportResult);
         });
@@ -17,7 +27,12 @@ describe('Reports:', () => {
     describe('jsonReport', () => {
         it('provides json report', () => {
             const reporter = new JsonReport();
-            reporter.prepareData(getDefaultConfig(), jsonRawReportResult);
+            reporter.prepareData({
+                startedAt: isoDate(),
+                completedAt: isoDate(),
+                config: getDefaultConfig(),
+                report: jsonRawReportResult,
+            });
 
             expect(reporter.exposeInternalView()).toEqual(jsonReportResult);
         });

--- a/src/lib/report/humanReport.ts
+++ b/src/lib/report/humanReport.ts
@@ -1,6 +1,4 @@
-import { IConfig } from '@/lib/config';
-import { IJsonReport } from '@/lib/dataProcessor';
-import { IReport } from '@/types';
+import { IPrepareDataParams, IReport } from '@/types';
 import cTable = require('console.table');
 import * as fs from 'fs-extra';
 import jstat from 'jstat';
@@ -31,7 +29,8 @@ export class HumanReport implements IReport {
         };
     }
 
-    public prepareData(config: IConfig, {data, sites}: IJsonReport) {
+    public prepareData({config, report}: IPrepareDataParams) {
+        const {sites, data} = report;
         const siteNames = sites.map((site) => site.name);
         const diffSiteNames = siteNames.filter((_, index) => index > 0);
         this.headers = [

--- a/src/lib/report/index.ts
+++ b/src/lib/report/index.ts
@@ -9,6 +9,8 @@ export { JsonReport } from './jsonReport';
 export async function saveReports({
     startedAt,
     completedAt,
+    status,
+    statusMessage,
     id,
     workDir,
     config,
@@ -17,6 +19,8 @@ export async function saveReports({
 }: {
     startedAt: string,
     completedAt: string,
+    status: string,
+    statusMessage: string,
     config: IConfig,
     jsonRawReport: IJsonRawReport,
     reporters: Class<IReport>[],
@@ -28,6 +32,8 @@ export async function saveReports({
         reporterInstance.prepareData({
             startedAt,
             completedAt,
+            status,
+            statusMessage,
             config,
             report: jsonRawReport,
         });

--- a/src/lib/report/index.ts
+++ b/src/lib/report/index.ts
@@ -7,12 +7,16 @@ export { HumanReport } from './humanReport';
 export { JsonReport } from './jsonReport';
 
 export async function saveReports({
+    startedAt,
+    completedAt,
     id,
     workDir,
     config,
     jsonRawReport,
     reporters,
 }: {
+    startedAt: string,
+    completedAt: string,
     config: IConfig,
     jsonRawReport: IJsonRawReport,
     reporters: Class<IReport>[],
@@ -21,7 +25,12 @@ export async function saveReports({
 }) {
     const reports = reporters.map((reporter) => {
         const reporterInstance = new reporter();
-        reporterInstance.prepareData(config, jsonRawReport);
+        reporterInstance.prepareData({
+            startedAt,
+            completedAt,
+            config,
+            report: jsonRawReport,
+        });
 
         return reporterInstance.saveToFs(workDir, id);
     });

--- a/src/lib/report/jsonReport.ts
+++ b/src/lib/report/jsonReport.ts
@@ -1,7 +1,6 @@
 import {PORCHMARK_REPORT_VERSION, PORCHMARK_VERSION} from '@/constants';
-import { IConfig, IConfigMetricsAggregation } from '@/lib/config';
-import { IJsonRawReport, IMetric } from '@/types';
-import { IReport, ISite } from '@/types';
+import { IConfigMetricsAggregation } from '@/lib/config';
+import { IMetric, IPrepareDataParams, IReport, ISite } from '@/types';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 
@@ -25,6 +24,8 @@ interface IJsonReportData {
 interface IJsonReport {
     version: string;
     reportVersion: number;
+    startedAt: string;
+    completedAt: string;
     sites: ISite[];
     metrics: IMetric[];
     metricAggregations: IConfigMetricsAggregation[];
@@ -32,12 +33,16 @@ interface IJsonReport {
 }
 
 export class JsonReport implements IReport {
+    private startedAt: string;
+    private completedAt: string;
     private sites: ISite[];
     private metrics: IMetric[];
     private metricAggregations: IConfigMetricsAggregation[];
     private data: IJsonReportData;
 
     public constructor() {
+        this.startedAt = '';
+        this.completedAt = '';
         this.sites = [];
         this.metrics = [];
         this.metricAggregations = [];
@@ -48,7 +53,9 @@ export class JsonReport implements IReport {
     }
 
     /* Obtain and convert JsonReport to internal view */
-    public prepareData(_: IConfig, report: IJsonRawReport) {
+    public prepareData({startedAt, completedAt, report}: IPrepareDataParams) {
+        this.startedAt = startedAt;
+        this.completedAt = completedAt;
         this.sites = report.sites;
         this.metrics = report.metrics;
         this.metricAggregations = report.metricAggregations;
@@ -72,6 +79,8 @@ export class JsonReport implements IReport {
         return {
             version: PORCHMARK_VERSION,
             reportVersion: PORCHMARK_REPORT_VERSION,
+            startedAt: this.startedAt,
+            completedAt: this.completedAt,
             sites: this.sites,
             metrics: this.metrics,
             metricAggregations: this.metricAggregations,

--- a/src/lib/report/jsonReport.ts
+++ b/src/lib/report/jsonReport.ts
@@ -1,3 +1,4 @@
+import {PORCHMARK_REPORT_VERSION, PORCHMARK_VERSION} from '@/constants';
 import { IConfig, IConfigMetricsAggregation } from '@/lib/config';
 import { IJsonRawReport, IMetric } from '@/types';
 import { IReport, ISite } from '@/types';
@@ -22,6 +23,8 @@ interface IJsonReportData {
 }
 
 interface IJsonReport {
+    version: string;
+    reportVersion: number;
     sites: ISite[];
     metrics: IMetric[];
     metricAggregations: IConfigMetricsAggregation[];
@@ -67,6 +70,8 @@ export class JsonReport implements IReport {
     /* For testing purposes only */
     public exposeInternalView() {
         return {
+            version: PORCHMARK_VERSION,
+            reportVersion: PORCHMARK_REPORT_VERSION,
             sites: this.sites,
             metrics: this.metrics,
             metricAggregations: this.metricAggregations,

--- a/src/lib/report/jsonReport.ts
+++ b/src/lib/report/jsonReport.ts
@@ -26,6 +26,8 @@ interface IJsonReport {
     reportVersion: number;
     startedAt: string;
     completedAt: string;
+    status: string;
+    statusMessage: string;
     sites: ISite[];
     metrics: IMetric[];
     metricAggregations: IConfigMetricsAggregation[];
@@ -35,6 +37,8 @@ interface IJsonReport {
 export class JsonReport implements IReport {
     private startedAt: string;
     private completedAt: string;
+    private status: string;
+    private statusMessage: string;
     private sites: ISite[];
     private metrics: IMetric[];
     private metricAggregations: IConfigMetricsAggregation[];
@@ -43,6 +47,8 @@ export class JsonReport implements IReport {
     public constructor() {
         this.startedAt = '';
         this.completedAt = '';
+        this.status = '';
+        this.statusMessage = '';
         this.sites = [];
         this.metrics = [];
         this.metricAggregations = [];
@@ -53,9 +59,12 @@ export class JsonReport implements IReport {
     }
 
     /* Obtain and convert JsonReport to internal view */
-    public prepareData({startedAt, completedAt, report}: IPrepareDataParams) {
+    public prepareData(params: IPrepareDataParams) {
+        const {startedAt, completedAt, status, statusMessage, report} = params;
         this.startedAt = startedAt;
         this.completedAt = completedAt;
+        this.status = status;
+        this.statusMessage = statusMessage;
         this.sites = report.sites;
         this.metrics = report.metrics;
         this.metricAggregations = report.metricAggregations;
@@ -81,6 +90,8 @@ export class JsonReport implements IReport {
             reportVersion: PORCHMARK_REPORT_VERSION,
             startedAt: this.startedAt,
             completedAt: this.completedAt,
+            status: this.status,
+            statusMessage: this.statusMessage,
             sites: this.sites,
             metrics: this.metrics,
             metricAggregations: this.metricAggregations,

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,9 +60,16 @@ export interface IJsonRawReport {
     data: IJsonRawReportData;
 }
 
+export interface IPrepareDataParams {
+    startedAt: string;
+    completedAt: string;
+    config: IConfig;
+    report: IJsonRawReport;
+}
+
 export interface IReport {
     /* Obtain and convert JsonReport to internal view */
-    prepareData(config: IConfig, data: IJsonRawReport): void;
+    prepareData(params: IPrepareDataParams): void;
 
     /* Flush internal data to file system */
     saveToFs(workDir: string, id: string): void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,8 @@ export interface IJsonRawReport {
 export interface IPrepareDataParams {
     startedAt: string;
     completedAt: string;
+    status: string;
+    statusMessage: string;
     config: IConfig;
     report: IJsonRawReport;
 }


### PR DESCRIPTION
### что тут происходит

несколько улучшений по формату json-отчета для того, чтобы мы могли сохранять результаты всех porchmark-проверок в БД, фильтровать и строить правильные отчеты

- Сохраняется конфиг в отдельный файл
- В report.json добавлены следующие поля:
  - version - string, версия porchmark
  - reportVersion - number, версия отчета, нужна чтобы в будущем можно было при необходимости поменять формат отчета и доработать скрипты парсинг и вставки в бд на работу с разными версиями отчета
  - startedAt - iso date, когда сравнение запустилось
  - completedAt - iso date, когда сравнение закончилось
  - status и statusMessage - string, должны понадобиться в будущем, когда мы выясним при каких значениях разница считается действительно значимой (либо просто по p-value), тогда будут добавлены статусы success, failure и вывод поясняющего statusMessage почему failure

так как пришлось менять формат prepareData сломалась совместимость с отчетом графичками https://github.com/re-gor/porchmark-pretty-reporter

Чтобы починить нужно перетащить [типизацию  туда](https://github.com/re-gor/porchmark-pretty-reporter/blob/master/src/types/porchmark/index.ts), исправить совместимость, опубликовать новую версию пакета, обновить пакет тут и раскомментировать две строчки -- сделаю следующим PR